### PR TITLE
update svelte from 1.8.0 to 1.12.1

### DIFF
--- a/compiler-no-html/package.js
+++ b/compiler-no-html/package.js
@@ -1,13 +1,13 @@
 Package.describe({
   name: 'svelte:compiler-no-html',
-  version: '1.1.0',
+  version: '1.2.0',
   summary: 'Svelte compiler (ignores HTML files)',
   git: 'https://github.com/meteor-svelte/meteor-svelte.git'
 });
 
 Package.registerBuildPlugin({
   name: 'svelte-compiler',
-  use: ['svelte:core@1.1.0'],
+  use: ['svelte:core@1.2.0'],
   sources: [
     'plugin.js'
   ]

--- a/compiler/package.js
+++ b/compiler/package.js
@@ -1,13 +1,13 @@
 Package.describe({
   name: 'svelte:compiler',
-  version: '1.2.0',
+  version: '1.3.0',
   summary: 'Svelte compiler',
   git: 'https://github.com/meteor-svelte/meteor-svelte.git'
 });
 
 Package.registerBuildPlugin({
   name: 'svelte-compiler',
-  use: ['svelte:core@1.1.0'],
+  use: ['svelte:core@1.2.0'],
   sources: [
     'plugin.js'
   ]

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'svelte:core',
-  version: '1.1.0',
+  version: '1.2.0',
   summary: 'Svelte compiler core',
   git: 'https://github.com/meteor-svelte/meteor-svelte.git'
 });
@@ -8,7 +8,7 @@ Package.describe({
 Npm.depends({
   htmlparser2: '3.9.2',
   'source-map': '0.5.6',
-  'svelte-es5-meteor': '0.3.0'
+  'svelte-es5-meteor': '0.4.0'
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
Requires using [svelte-es5-meteor PR #1](https://github.com/meteor-svelte/svelte-es5-meteor/pull/1), which updates the "svelte" dev dependency, and then publishing that with a minor version bump to "0.4.0".