### PR TITLE
Enable runtime checks during development

### DIFF
--- a/compiler/package.js
+++ b/compiler/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'svelte:compiler',
-  version: '1.27.0_1',
+  version: '1.27.0_2',
   summary: 'Svelte compiler',
   git: 'https://github.com/meteor-svelte/meteor-svelte.git',
   documentation: '../README.md'
@@ -8,7 +8,7 @@ Package.describe({
 
 Package.registerBuildPlugin({
   name: 'svelte-compiler',
-  use: ['ecmascript@0.6.1', 'svelte:core@1.27.0_1'],
+  use: ['ecmascript@0.6.1', 'svelte:core@1.27.0_2'],
   sources: [
     'plugin.js'
   ]

--- a/core/package.js
+++ b/core/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'svelte:core',
-  version: '1.27.0_1',
+  version: '1.27.0_2',
   summary: 'Svelte compiler core',
   git: 'https://github.com/meteor-svelte/meteor-svelte.git'
 });

--- a/core/svelte-compiler.js
+++ b/core/svelte-compiler.js
@@ -74,6 +74,7 @@ SvelteCompiler = class extends CachingCompiler {
 
     try {
       const compiled = svelte.compile(raw, {
+        dev: process.env.NODE_ENV !== 'production',
         filename: path,
         name: basename
           .slice(0, basename.indexOf('.')) // Remove extension


### PR DESCRIPTION
Svelte has a [`dev` option](https://github.com/sveltejs/svelte#options) that enables runtime checks. For example, if a component uses a data property that isn't included in the `data` object, the warning `Component was created without expected data property 'testProperty'` is shown in the browser console:

```html
<div>{{testProperty}}</div>
```

```js
new Component({
  target: document.querySelector('#root'),
  // data: { testProperty: ':D' }
});
```

We could make this option configurable but I think it's good to always enable it during development (similar to React).