### PR TITLE
Add support for server-side rendering

### DIFF
--- a/compiler/package.js
+++ b/compiler/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'svelte:compiler',
-  version: '1.60.3_1',
+  version: '1.60.3-beta.0_1',
   summary: 'Svelte compiler',
   git: 'https://github.com/meteor-svelte/meteor-svelte.git',
   documentation: '../README.md'
@@ -8,7 +8,7 @@ Package.describe({
 
 Package.registerBuildPlugin({
   name: 'svelte-compiler',
-  use: ['ecmascript@0.9.0', 'svelte:core@1.60.3_1'],
+  use: ['ecmascript@0.9.0', 'svelte:core@1.60.3-beta.0_1'],
   sources: [
     'plugin.js'
   ],

--- a/compiler/plugin.js
+++ b/compiler/plugin.js
@@ -15,4 +15,4 @@ Plugin.registerCompiler({
     'html',
     'svelte'
   ]
-}, () => new SvelteCompiler);
+}, () => new SvelteCompiler(options));

--- a/core/package.js
+++ b/core/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'svelte:core',
-  version: '1.60.3_1',
+  version: '1.60.3-beta.0_1',
   summary: 'Svelte compiler core',
   git: 'https://github.com/meteor-svelte/meteor-svelte.git'
 });

--- a/core/svelte-compiler.js
+++ b/core/svelte-compiler.js
@@ -3,11 +3,13 @@ import sourcemap from 'source-map';
 import svelte from 'svelte';
 
 SvelteCompiler = class extends CachingCompiler {
-  constructor() {
+  constructor(options = {}) {
     super({
       compilerName: 'svelte',
       defaultCacheSize: 1024 * 1024 * 10
     });
+
+    this.options = options;
   }
 
   getCacheKey(file) {


### PR DESCRIPTION
This PR adds support for server-side rendering. Svelte components are automatically compiled for SSR if they are imported on the server so that they can be rendered in [`onPageLoad`](https://docs.meteor.com/packages/server-render.html). Additionally, two compiler options for `package.json` (`hydratable` and `css`) can be used to control which client-side functionality related to SSR should be included in generated components. You probably want to set `hydratable` to `true` and `css` to `false` (see the Svelte docs: [Hydration](https://svelte.technology/guide#hydration) and [Server-side API](https://svelte.technology/guide#server-side-api)):

```
{
  ...
  "svelte:compiler": {
    "hydratable": true,
    "css": false
  }
}
```

Maybe it would make sense to combine these two options into a single `ssr` option (where `ssr = true` would mean `hydratable = true` and `css = false`), so this might change until the final release. :slightly_smiling_face:

If you want to try out SSR (:wave: @faburem), clone the [`ssr-example`](https://github.com/meteor-svelte/ssr-example) repo or add the beta pre-release to your app:

```sh
meteor add svelte:compiler@=1.60.3-beta.0_1
```

Fixes #13