### PR TITLE
Load svelte, other packages from user's node_modules

### DIFF
--- a/package.js
+++ b/package.js
@@ -21,8 +21,7 @@ Package.registerBuildPlugin({
     '@babel/runtime': '7.4.3',
     'find-up': '3.0.0',
     htmlparser2: '3.10.1',
-    'source-map': '0.5.6',
-    svelte: '3.6.7'
+    'source-map': '0.5.6'
   }
 });
 


### PR DESCRIPTION
This PR removes `svelte` from the npm list, and attempts to load modules from the user's `node_modules` folder.

Since Svelte must be included in the user's `package.json` file, it was removed from `package.js`. Meteor will kick up an appropriate warning as soon as it finds a .svelte file without `svelte` installed.

`source-maps` and `htmlparser2' are both still included in `package.js`, but will also attempt to load the version from the user's `node_modules` directory, so that they can update minor releases, etc. independent of this package.

We can also add a nice version check to make sure the user has appropriate versions of the above packages. `htmlparser2` 4.0.0 doesn't seem to work for example.

This addresses issue #11 