### PR TITLE
Tracker reactive statements

### DIFF
--- a/package.js
+++ b/package.js
@@ -22,17 +22,21 @@ Package.registerBuildPlugin({
     'find-up': '3.0.0',
     htmlparser2: '3.10.1',
     'postcss': '7.0.17',
-    'source-map': '0.5.6'
+    'source-map': '0.5.6',
+    'recast': '0.19.0',
+    'periscopic': '2.0.2'
   }
 });
 
 Package.onUse(function (api) {
   api.versionsFrom('1.8');
   api.use('isobuild:compiler-plugin@1.0.0');
+  api.use('modules');
+  api.use('tracker', 'client');
+  api.addFiles('tracker.js', 'client');
 
   // Dependencies for compiled Svelte components (taken from `ecmascript`).
   api.imply([
-    'modules',
     'ecmascript-runtime',
     'babel-runtime',
     'promise'

--- a/tracker.js
+++ b/tracker.js
@@ -1,0 +1,24 @@
+const { onDestroy } = require('svelte');
+const { Tracker } = require('meteor/tracker');
+
+module.exports = {
+  createReactiveWrapper() {
+    let computation = null;
+
+    onDestroy(() => {
+      if (computation) {
+        computation.stop();
+      }
+    });
+
+    return function (func) {
+      if (computation) {
+        computation.stop();
+      }
+
+      computation = Tracker.autorun(func);
+
+      return computation;
+    }
+  }
+}


### PR DESCRIPTION
In addition to the `$` reactive statements, this adds a preprocessor to support `$m` tracker reactive statements. Statements starting with `$m:` will rerun when dependencies Svelte has detected are invalidated or when Tracker dependencies used in the statement are invalidated.

Example:

Original content in `<script>`
```js
  $m: appCount = Apps.find().count();
  $m: userId = Meteor.userId();
  $: doubledCount = appCount * 2;
```

After preprocessor:
```js
  import { createReactiveWrapper as _m_createReactiveWrapper } from "meteor/svelte:compiler/tracker";
  const _m_tracker1 = _m_createReactiveWrapper();
  const _m_tracker0 = _m_createReactiveWrapper();
  let userId;
  let appCount;

  $:
  _m_tracker0(() => {
    appCount = Apps.find().count();
  });

  $:
  _m_tracker1(() => {
    userId = Meteor.userId();
  });

  $: doubledCount = appCount * 2;
```

Problems:
- I haven't tested this with SSR
- Due to wrapping the reactive statements, Svelte is no longer able to detect missing variable declarations and add them. The preprocessor implements this with one main difference: if the variable is declared in a module script, Svelte correctly does not inject a declaration while the preprocessor does. Since variables declared in the module script are not reactive, this situation is probably very rare.